### PR TITLE
Add symbolize_names on loading YAML file.

### DIFF
--- a/lib/brutal/configuration.rb
+++ b/lib/brutal/configuration.rb
@@ -9,13 +9,14 @@ module Brutal
   class Configuration
     NAME = '.brutal.yml'
     PATH = ::File.join(::Dir.pwd, NAME).freeze
+    DEFAULT_HEADER = '# Brutal test suite'
 
     def self.load!
       new.to_a
     end
 
     def self.file!
-      ::YAML.load_file(PATH)
+      ::YAML.load(File.read(PATH), symbolize_names: true)
     rescue ::Errno::ENOENT => _e
       abort("File #{PATH} not found!")
     end
@@ -26,10 +27,10 @@ module Brutal
     def initialize
       settings = self.class.file!
 
-      @header   = settings.fetch('header',   '# Brutal test suite')
-      @subject  = settings.fetch('subject',  '')
-      @contexts = settings.fetch('contexts', {})
-      @actuals  = settings.fetch('actuals',  [])
+      @header   = settings.fetch(:header,   DEFAULT_HEADER)
+      @subject  = settings.fetch(:subject,  '')
+      @contexts = settings.fetch(:contexts, {})
+      @actuals  = settings.fetch(:actuals,  [])
 
       raise ::TypeError, @header.inspect   unless @header.is_a?(::String)
       raise ::TypeError, @subject.inspect  unless @subject.is_a?(::String)

--- a/test.rb
+++ b/test.rb
@@ -5,28 +5,50 @@ require 'simplecov'
 ::SimpleCov.command_name 'Brutal test suite'
 ::SimpleCov.start
 
-require './lib/brutal/scaffold'
+%w[configuration scaffold].each { |file_name| require "./lib/brutal/#{file_name}" }
 
 # ------------------------------------------------------------------------------
 
-actual = begin
-  ::Brutal::Scaffold.new("# frozen_string_literal: true", '"Hello " + "%{string}"', *"%{subject}.length", **{:string=>["Alice", "Bob"]})
-end
+settings = YAML.load(<<-SETTINGS, symbolize_names: true)
+                     subject: |
+                       "Hello " + "%{string}"
+                     contexts:
+                       string:
+                         - Alice
+                         - Bob
+                     actuals:
+                       - "%{subject}.length"
+                     SETTINGS
+
+::Brutal::Configuration.module_eval("def self.file!; #{settings}; end")
+
+actual = ::Brutal::Scaffold.new(*::Brutal::Configuration.load!)
 
 raise if actual.blank_line != "\n# ------------------------------------------------------------------------------\n\n"
 raise if actual.context_names != [:string]
 raise if actual.contexts_values != [["Alice", "Bob"]]
 raise if actual.combinations_values != [["Alice"], ["Bob"]]
-raise if actual.to_s != "# frozen_string_literal: true\n\n# ------------------------------------------------------------------------------\n\nactual = begin\n  \"Hello \" + \"Alice\"\nend\n\nraise if actual.length != 11\n\n# ------------------------------------------------------------------------------\n\nactual = begin\n  \"Hello \" + \"Bob\"\nend\n\nraise if actual.length != 9\n"
+raise if actual.to_s != "#{::Brutal::Configuration::DEFAULT_HEADER}\n\n# ------------------------------------------------------------------------------\n\nactual = begin\n  \"Hello \" + \"Alice\"\nend\n\nraise if actual.length != 11\n\n# ------------------------------------------------------------------------------\n\nactual = begin\n  \"Hello \" + \"Bob\"\nend\n\nraise if actual.length != 9\n"
 
 # ------------------------------------------------------------------------------
 
-actual = begin
-  ::Brutal::Scaffold.new("# frozen_string_literal: true", '"Hello " + "%{string}"', *"%{subject}.to_s", **{:string=>["Alice", "Bob"]})
-end
+settings = YAML.load(<<-SETTINGS, symbolize_names: true)
+                     subject: |
+                       "Hello " + "%{string}"
+                     contexts:
+                       string:
+                         - Alice
+                         - Bob
+                     actuals:
+                       - "%{subject}.to_s"
+                     SETTINGS
+
+::Brutal::Configuration.module_eval("def self.file!; #{settings}; end")
+
+actual = ::Brutal::Scaffold.new(*::Brutal::Configuration.load!)
 
 raise if actual.blank_line != "\n# ------------------------------------------------------------------------------\n\n"
 raise if actual.context_names != [:string]
 raise if actual.contexts_values != [["Alice", "Bob"]]
 raise if actual.combinations_values != [["Alice"], ["Bob"]]
-raise if actual.to_s != "# frozen_string_literal: true\n\n# ------------------------------------------------------------------------------\n\nactual = begin\n  \"Hello \" + \"Alice\"\nend\n\nraise if actual.to_s != \"Hello Alice\"\n\n# ------------------------------------------------------------------------------\n\nactual = begin\n  \"Hello \" + \"Bob\"\nend\n\nraise if actual.to_s != \"Hello Bob\"\n"
+raise if actual.to_s != "#{::Brutal::Configuration::DEFAULT_HEADER}\n\n# ------------------------------------------------------------------------------\n\nactual = begin\n  \"Hello \" + \"Alice\"\nend\n\nraise if actual.to_s != \"Hello Alice\"\n\n# ------------------------------------------------------------------------------\n\nactual = begin\n  \"Hello \" + \"Bob\"\nend\n\nraise if actual.to_s != \"Hello Bob\"\n"


### PR DESCRIPTION
There's an error when running `brutal` in Ruby versions under 2.7.0, since the double splat operator doesn't accept string keys:

```bash
$ brutal
~/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/brutal-1.0.0/lib/brutal/configuration.rb:42:in `to_a': hash key "string" is not a Symbol (TypeError)
```
The problem is at the moment of producing the hash from the configuration with `YAML.load_file`, which returns a hash with string keys.

I've done a few changes to use `YAML.load` instead, so we can use the `symbolize_names` option to get symbol keys and also updated the lines where the instance variables are initialized in the Brutal::Configuration constructor.

I updated the test.rb file to redefine `Brutal::Configuration.file!` before each scenario to avoid hardcoding the parameters for Brutal::Scaffolding.

